### PR TITLE
Added master license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,73 @@
+# bioBakery Software Licensing
+
+The bioBakery Lab develops and distributes software, databases, reference catalogs, and related resources for microbiome and multi-omics research.
+
+Unless otherwise noted, software developed by the bioBakery Lab is distributed under the [MIT License](https://opensource.org/license/mit).
+
+
+
+---
+
+## bioBakery Data Resources
+
+Databases, annotations, and reference resources developed solely by the bioBakery Lab are distributed under the [MIT License](https://opensource.org/license/mit).
+
+When applied to data resources, users are requested to provide attribution consistent with academic norms and citation practices.
+
+---
+
+## Third-Party Data Sources
+
+Certain bioBakery databases incorporate information derived from third-party resources that are subject to additional licensing requirements.
+
+### KEGG
+
+KEGG-derived content is subject to the KEGG academic license and associated attribution requirements.
+
+References:
+
+- https://www.kegg.jp
+- https://www.kegg.jp/kegg/legal.html
+
+---
+
+### MetaCyc
+
+MetaCyc-derived content is subject to the MetaCyc academic license and associated attribution requirements.
+
+References:
+
+- https://metacyc.org
+- https://biocyc.org
+
+---
+
+### ChocoPhlAn and Derived Databases
+
+ChocoPhlAn databases and derived database releases may be used with their associated bioBakery software.
+
+These databases may not be redistributed, modified, or used for purposes outside of their intended software ecosystem except as permitted by the applicable database license.
+
+
+---
+
+## License Precedence
+
+Where third-party licensing terms apply, those terms supersede the general MIT licensing terms described above for the affected data resources.
+
+Software licensing and database licensing may differ. Users are responsible for complying with the applicable terms associated with all software, databases, annotations, and reference resources they use.
+
+---
+
+## Attribution
+
+Users redistributing bioBakery software, databases, or derivative works should preserve:
+
+- Copyright notices
+- License notices
+- Attribution requirements
+- Required citations associated with third-party resources
+
+---
+
+Questions regarding licensing or redistribution should be directed to the maintainers of the relevant [bioBakery Lab](https://forum.biobakery.org/).


### PR DESCRIPTION
Add a top-level licensing document to clarify bioBakery's licensing strategy. Software and bioBakery-developed data resources remain MIT licensed, while documenting additional licensing requirements for databases that incorporate third-party resources such as KEGG, MetaCyc, and ChocoPhlAn-derived content.